### PR TITLE
Bug orientation crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden"
             android:theme="@style/Theme.SimplyWords">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/sg/edu/np/mad/simplywords/SimplifyFragment.java
+++ b/app/src/main/java/sg/edu/np/mad/simplywords/SimplifyFragment.java
@@ -89,6 +89,7 @@ public class SimplifyFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         View view = inflater.inflate(R.layout.fragment_simplify, container, false);
         TextRecognizer recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS);
 
@@ -111,8 +112,11 @@ public class SimplifyFragment extends Fragment {
                 Log.d("SimplifyFragment", "takePictureLauncher: operation was successful");
 
                 try{
+
                     File imageFile = new File(currentImagePath);
-                    Log.d("SimplifyFragment", "takePictureLauncher: got image file...");
+                    Log.d("SimplifyFragment", "takePictureLauncher: got image file..."+imageFile);
+
+
                     Bitmap imageBitMap= BitmapFactory.decodeFile(imageFile.getAbsolutePath());
                     Log.d("SimplifyFragment", "takePictureLauncher: converted file to bitmap...");
 
@@ -429,6 +433,10 @@ public class SimplifyFragment extends Fragment {
             }
         }
 
+    }
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        // Save relevant state data here
     }
     /** Check if this device has a camera */
     private boolean checkCameraHardware(Context context) {

--- a/app/src/main/java/sg/edu/np/mad/simplywords/SimplyWordsService.java
+++ b/app/src/main/java/sg/edu/np/mad/simplywords/SimplyWordsService.java
@@ -65,8 +65,11 @@ public class SimplyWordsService extends Service {
         super.onStartCommand(intent, flags, startId);
 
         // Creates and shows a new instance of the overlay
-        Log.d("SimplyWordsService", "instanciating overlay...");
-        overlay = new SummaryOverlay(this);
+        if (overlay == null) {
+            Log.d("SimplyWordsService", "instanciating overlay...");
+            overlay = new SummaryOverlay(this);
+        }
+
         Log.d("SimplyWordsService", "showing overlay...");
         overlay.showOverlay();
         overlay.updateProgress(-1);

--- a/app/src/main/java/sg/edu/np/mad/simplywords/SimplyWordsService.java
+++ b/app/src/main/java/sg/edu/np/mad/simplywords/SimplyWordsService.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.IBinder;
+import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
@@ -21,7 +22,7 @@ public class SimplyWordsService extends Service {
     private final BroadcastReceiver receiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if ("overlay_destroyed".equals(intent.getAction())) {
+            if ("sg.edu.np.mad.simplywords.OVERLAY_DESTROYED".equals(intent.getAction())) {
                 stopSelf();
             }
         }
@@ -47,8 +48,8 @@ public class SimplyWordsService extends Service {
         mRepository = new SummaryRepository(getApplication());
 
         // Registers the broadcast receiver to receive text from other apps
-        IntentFilter overlayDestructionFilter = new IntentFilter("overlay_destroyed");
-        registerReceiver(receiver, overlayDestructionFilter);
+        IntentFilter overlayDestructionFilter = new IntentFilter("sg.edu.np.mad.simplywords.OVERLAY_DESTROYED");
+        registerReceiver(receiver, overlayDestructionFilter,RECEIVER_EXPORTED);
     }
 
     @Override
@@ -64,7 +65,9 @@ public class SimplyWordsService extends Service {
         super.onStartCommand(intent, flags, startId);
 
         // Creates and shows a new instance of the overlay
+        Log.d("SimplyWordsService", "instanciating overlay...");
         overlay = new SummaryOverlay(this);
+        Log.d("SimplyWordsService", "showing overlay...");
         overlay.showOverlay();
         overlay.updateProgress(-1);
         String originalText = intent.getStringExtra(Constants.EXTRA_ORIGINAL_TEXT);

--- a/app/src/main/res/layout/overlay_summary.xml
+++ b/app/src/main/res/layout/overlay_summary.xml
@@ -29,7 +29,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:src="@drawable/baseline_drag_indicator_24"
-                    app:tint="?attr/colorPrimary"
+                    app:tint="?attr/colorSurfaceInverse"
                     android:padding="1dp"
                     android:id="@+id/overlay_summary_drag"
 


### PR DESCRIPTION
This PR fixes 
1. app crashing when a user changes orientation when entering the camera action
2. Overlay crashing when starting it due to lack of permission declaration.
3. Multiple overlays showing if the user does not close the old one and starts another summary request

Recommended to merge this PR as fast as possible as these are core features that are not working